### PR TITLE
Add EduButton component

### DIFF
--- a/packages/react/src/components/EduButton/EduButton.stories.js
+++ b/packages/react/src/components/EduButton/EduButton.stories.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import EduButton from './EduButton';
+
+export default {
+  title: 'EduComponents/EduButton',
+  component: EduButton,
+};
+
+export const Default = () => <EduButton>Edu Button</EduButton>;

--- a/packages/react/src/components/EduButton/EduButton.tsx
+++ b/packages/react/src/components/EduButton/EduButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Button, { type ButtonProps } from '../Button';
+import { eduColors } from '../../tokens/edu-tokens';
+
+export interface EduButtonProps extends ButtonProps {
+  /** Custom inline style */
+  style?: React.CSSProperties;
+}
+
+const EduButton = React.forwardRef<HTMLButtonElement, EduButtonProps>(
+  function EduButton({ style, ...rest }, ref) {
+    const defaultStyle = {
+      backgroundColor: eduColors.primary,
+      color: eduColors.onPrimary,
+    } as React.CSSProperties;
+    return <Button ref={ref} style={{ ...defaultStyle, ...style }} {...rest} />;
+  }
+);
+
+EduButton.displayName = 'EduButton';
+
+export default EduButton;

--- a/packages/react/src/components/EduButton/__tests__/EduButton-test.js
+++ b/packages/react/src/components/EduButton/__tests__/EduButton-test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import EduButton from '../EduButton';
+
+describe('EduButton', () => {
+  it('renders with default styles', () => {
+    render(<EduButton>Test</EduButton>);
+    const button = screen.getByRole('button');
+    expect(button).toHaveStyle({ backgroundColor: '#005ae1' });
+  });
+});

--- a/packages/react/src/components/EduButton/index.ts
+++ b/packages/react/src/components/EduButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from './EduButton';
+export type { EduButtonProps } from './EduButton';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -629,3 +629,5 @@ export type { SwitcherItemProps } from './components/UIShell/SwitcherItem';
 
 //unordered list
 export type { UnorderedListProps } from './components/UnorderedList/UnorderedList';
+export * from './components/EduButton';
+export * from './tokens/edu-tokens';

--- a/packages/react/src/tokens/edu-tokens.ts
+++ b/packages/react/src/tokens/edu-tokens.ts
@@ -1,0 +1,6 @@
+export const eduColors = {
+  primary: '#005ae1',
+  onPrimary: '#ffffff',
+  secondary: '#ffdd00',
+  onSecondary: '#000000',
+};


### PR DESCRIPTION
## Summary
- add sample Edu design tokens
- implement `EduButton` using tokens
- export new component and tokens
- include storybook demo and unit test

## Testing
- `yarn test packages/react/src/components/EduButton/__tests__/EduButton-test.js`


------
https://chatgpt.com/codex/tasks/task_e_6888e1bc2ba4832a838501e1f3aed3fc